### PR TITLE
Add max-score to `action.yml` and `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 | `expected-output` | The expected output that the command should print to stdout. | Yes |
 | `comparison-method` | Defines how the stdout output will be compared. Supported values are `included`, `exact`, and `regex`. | Yes |
 | `timeout` | Duration (in minutes) before the test is terminated. Defaults to 10 minutes with a maximum limit of 6 hours.| No |
+| `max-score` | The maximum amount of points a student can receive for this test.| No |
+
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
     description: "Duration (in minutes) before the test is terminated. Defaults to 10 minutes with a maximum limit of 60 minutes."
     default: "10"
     required: false
+  max-score:
+    description: "The maximum amount of points a student can receive for this test."
+    required: false
 outputs:
   result:
     description: "Outputs the result of the grader, indicating the success or failure of the test."


### PR DESCRIPTION

This pull request adds a new `max-score` field to both `README.md` and `action.yml` to define the maximum points a student can receive for a test.

* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23-R24">`README.md`</a>: Added a new `max-score` field to define the maximum points a student can receive for a test.
* <a href="diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R27-R29">`action.yml`</a>: Added a new `max-score` field to the `inputs:` section to define the maximum points a student can receive for a test.