### PR TITLE
add `error` option to status + fix test

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -3,7 +3,7 @@ const cp = require('child_process')
 const path = require('path')
 
 const node = process.execPath
-const ip = path.join(__dirname, '..', 'dist', 'main.js')
+const ip = path.join(__dirname, '..', 'src', 'main.js')
 
 function runTestWithEnv(env) {
   const options = {
@@ -128,7 +128,7 @@ test('handles command timeout correctly', () => {
     INPUT_TIMEOUT: '0.01', // 1 second Timeout
   })
 
-  expect(result.tests[0].status).toBe('fail')
+  expect(result.tests[0].status).toBe('error')
   expect(result.tests[0].message).toContain('Command was killed due to timeout')
 })
 

--- a/src/main.js
+++ b/src/main.js
@@ -107,7 +107,7 @@ function run() {
     let score = inputs.maxScore
 
     if (error) {
-      status = 'fail'
+      status = 'error'
       message = error
       score = 0
     } else if (!compareOutput(output, inputs.expectedOutput, inputs.comparisonMethod)) {
@@ -138,11 +138,11 @@ function run() {
   } catch (error) {
     const result = {
       version: 1,
-      status: 'fail',
+      status: 'error',
       tests: [
         {
           name: inputs.testName || 'Unknown Test',
-          status: 'fail',
+          status: 'error',
           message: error.message,
           test_code: `${inputs.command || 'Unknown Command'} <stdin>${inputs.input || ''}`,
           filename: '',


### PR DESCRIPTION
This pull request adds the `error` option to the status field inside the JSON that's returned by this runner. Also runs our tests off of `src/main.js` instead of `dist/main.js` since `dist/main.js` will only be on our release branch. 